### PR TITLE
Add Tab Definition Modifier

### DIFF
--- a/Sources/Calligraphy/StringComposition/Blank.swift
+++ b/Sources/Calligraphy/StringComposition/Blank.swift
@@ -24,6 +24,7 @@
 // SOFTWARE.
 
 /// A blank string component that produces an empty string.
+@available(macOS 14.0, macCatalyst 17.0, iOS 17.0, watchOS 10.0, tvOS 17.0, visionOS 1.0, *)
 public struct Blank: StringComponent {
 
     // MARK: - Initializers

--- a/Sources/Calligraphy/StringComposition/EmptyStringComponent.swift
+++ b/Sources/Calligraphy/StringComposition/EmptyStringComponent.swift
@@ -24,6 +24,7 @@
 // SOFTWARE.
 
 /// An empty string component
+@available(macOS 14.0, macCatalyst 17.0, iOS 17.0, watchOS 10.0, tvOS 17.0, visionOS 1.0, *)
 public struct EmptyStringComponent: StringComponent {
 
     /// Create an empty string component

--- a/Sources/Calligraphy/StringComposition/Frozen.swift
+++ b/Sources/Calligraphy/StringComposition/Frozen.swift
@@ -45,7 +45,7 @@ public struct Frozen: StringComponent {
     public init(
         @StringBuilder components: () -> some StringComponent
     ) {
-        _content = components()._content
+        _content = String.build { components() }
     }
 
     // MARK: - StringComponent

--- a/Sources/Calligraphy/StringComposition/Joined.swift
+++ b/Sources/Calligraphy/StringComposition/Joined.swift
@@ -85,7 +85,7 @@ public struct Joined<T, Separator>: StringComponent where T: StringComponent, Se
     // MARK: - StringComponent
 
     public var _content: String? {
-        StringBuilder.$separator.withValue(String(separator)) {
+        StringEnvironment.$activeSeparator.withValue(String(separator)) {
             components._content
         }
     }

--- a/Sources/Calligraphy/StringComposition/StringBuilder.swift
+++ b/Sources/Calligraphy/StringComposition/StringBuilder.swift
@@ -116,7 +116,7 @@ public enum StringBuilder {
                     return
                 }
                 if let r = result {
-                    result = r + StringBuilder.separator + content
+                    result = r + StringEnvironment.activeSeparator + content
                 } else {
                     result = content
                 }
@@ -175,7 +175,7 @@ public enum StringBuilder {
                         return prev
                     }
                     if let prev {
-                        return prev + StringBuilder.separator + content
+                        return prev + StringEnvironment.activeSeparator + content
                     } else {
                         return content
                     }
@@ -196,7 +196,14 @@ public enum StringBuilder {
 
     }
 
+}
+
+enum StringEnvironment {
+
     @TaskLocal
-    static var separator = "\n"
+    static var activeSeparator = "\n"
+
+    @TaskLocal
+    static var activeTabDefinition: Tab.Definition = .default
 
 }

--- a/Sources/Calligraphy/StringComposition/Tab.swift
+++ b/Sources/Calligraphy/StringComposition/Tab.swift
@@ -37,11 +37,36 @@ public struct Tab: StringComponent {
     // MARK: - StringComponent
 
     public var body: some StringComponent {
-        Line {
-            for _ in 0 ..< 4 {
-                Space()
+        _Guts(StringEnvironment.activeTabDefinition)
+    }
+
+    public enum Definition: Sendable {
+        case tab
+        case spaces(Int)
+        public static let `default`: Definition = .spaces(2)
+    }
+
+    private struct _Guts: StringComponent {
+
+        init(_ definition: Tab.Definition) {
+            self.definition = definition
+        }
+
+        var body: some StringComponent {
+            switch definition {
+            case .tab:
+                "\t"
+            case let .spaces(count):
+                Line {
+                    for _ in 0 ..< count {
+                        Space()
+                    }
+                }
             }
         }
+
+        private let definition: Tab.Definition
+
     }
 
 }

--- a/Sources/Calligraphy/StringComposition/TabDefinition.swift
+++ b/Sources/Calligraphy/StringComposition/TabDefinition.swift
@@ -1,5 +1,5 @@
 // Calligraphy
-// TabTests.swift
+// TabDefinition.swift
 //
 // MIT License
 //
@@ -23,31 +23,36 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import Calligraphy
-import Testing
+@available(macOS 14.0, macCatalyst 17.0, iOS 17.0, watchOS 10.0, tvOS 17.0, visionOS 1.0, *)
+extension StringComponent {
 
-@Suite("Tab Tests", .tags(.stringComposition))
-struct TabTests {
-
-    @Test("Tab Character Component")
-    func characterTab() {
-        let tab = Tab()
-            .tabDefinition(.tab)
-        #expect(tab._content == "\t")
+    public func tabDefinition(
+        _ definition: Tab.Definition
+    ) -> some StringComponent {
+        TabDefinition(self, definition: definition)
     }
 
-    @Test("Spaces Tab Component")
-    func spacesTab() {
-        let tab = Tab()
-            .tabDefinition(.spaces(3))
-        #expect(tab._content == "   ")
+}
+
+@available(macOS 14.0, macCatalyst 17.0, iOS 17.0, watchOS 10.0, tvOS 17.0, visionOS 1.0, *)
+struct TabDefinition<T>: StringComponent where T: StringComponent {
+
+    init(_ wrapped: T, definition: Tab.Definition) {
+        self.wrapped = wrapped
+        self.definition = definition
     }
 
-    @Test("Default Tab Component")
-    func defaultTab() {
-        let tab = Tab()
-            .tabDefinition(.default)
-        #expect(tab._content == "  ")
+    var _content: String? {
+        StringEnvironment.$activeTabDefinition.withValue(definition) {
+            wrapped._content
+        }
     }
+
+    var body: Never {
+        fatalErrorImperativeStringComponent()
+    }
+
+    private let wrapped: T
+    private let definition: Tab.Definition
 
 }

--- a/Tests/CalligraphyTests/StringComposition/TabDefinitionTests.swift
+++ b/Tests/CalligraphyTests/StringComposition/TabDefinitionTests.swift
@@ -1,5 +1,5 @@
 // Calligraphy
-// TabTests.swift
+// TabDefinitionTests.swift
 //
 // MIT License
 //
@@ -26,28 +26,44 @@
 import Calligraphy
 import Testing
 
-@Suite("Tab Tests", .tags(.stringComposition))
-struct TabTests {
+@Suite("Tab Definition Tests", .tags(.stringComposition))
+public struct TabLengthTests {
 
-    @Test("Tab Character Component")
-    func characterTab() {
-        let tab = Tab()
-            .tabDefinition(.tab)
-        #expect(tab._content == "\t")
+    @Test("Default tab definition")
+    func defaultLength() {
+        let list = Lines {
+            "foo"
+            "bar"
+            "baz"
+        }
+        .tabbed()
+
+        let expected = """
+          foo
+          bar
+          baz
+        """
+
+        #expect(list._content == expected)
     }
 
-    @Test("Spaces Tab Component")
-    func spacesTab() {
-        let tab = Tab()
-            .tabDefinition(.spaces(3))
-        #expect(tab._content == "   ")
-    }
+    @Test("Custom tab definition")
+    func customLength() {
+        let list = Lines {
+            "foo"
+            "bar"
+            "baz"
+        }
+        .tabbed()
+        .tabDefinition(.spaces(4))
 
-    @Test("Default Tab Component")
-    func defaultTab() {
-        let tab = Tab()
-            .tabDefinition(.default)
-        #expect(tab._content == "  ")
+        let expected = """
+            foo
+            bar
+            baz
+        """
+
+        #expect(list._content == expected)
     }
 
 }

--- a/Tests/CalligraphyTests/StringComposition/TabbedTests.swift
+++ b/Tests/CalligraphyTests/StringComposition/TabbedTests.swift
@@ -38,9 +38,9 @@ struct TabbedTests {
         }
 
         let expected = #"""
-            foo
-            bar
-            baz
+          foo
+          bar
+          baz
         """#
 
         #expect(tabbed._content == expected)
@@ -56,9 +56,9 @@ struct TabbedTests {
         .tabbed(2)
 
         let expected = #"""
-                foo
-                bar
-                baz
+            foo
+            bar
+            baz
         """#
 
         #expect(tabbed._content == expected)


### PR DESCRIPTION
Enable users to define the shape of a tab using `.tabDefinition(_:)`.

The default definition is two spaces.